### PR TITLE
Set site background to purple

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,7 +4,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: #800080;
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -77,7 +77,7 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: #800080;
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary
- update the global background color tokens to purple for both light and dark themes

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e10104061c83228fac1a880f2bb343